### PR TITLE
Remove unintended side effects of accessing toast.notificationView

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -285,6 +285,8 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
 
 @interface CRToast ()
 @property (nonatomic, readonly) BOOL snapshotWindow;
+@property (strong, nonatomic) CRToastView *privateNotificationView;
+@property (strong, nonatomic) UIView *privateStatusBarView;
 @end
 
 @implementation CRToast
@@ -426,10 +428,16 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
 #pragma mark - Notification View Helpers
 
 - (UIView*)notificationView {
-    CGSize size = CRNotificationViewSize(self.notificationType, self.preferredHeight);
-    CRToastView *notificationView = [[CRToastView alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height)];
-    notificationView.toast = self;
-    return notificationView;
+    return self.privateNotificationView;
+}
+
+- (UIView *)privateNotificationView {
+    if (!_privateNotificationView) {
+        CGSize size = CRNotificationViewSize(self.notificationType, self.preferredHeight);
+        _privateNotificationView = [[CRToastView alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height)];
+        _privateNotificationView.toast = self;
+    }
+    return _privateNotificationView;
 }
 
 - (CGRect)notificationViewAnimationFrame1 {
@@ -441,12 +449,18 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
 }
 
 - (UIView*)statusBarView {
-    UIView *statusBarView = [[UIView alloc] initWithFrame:self.statusBarViewAnimationFrame1];
-    if (self.snapshotWindow) {
-        [statusBarView addSubview:CRStatusBarSnapShotView(self.displayUnderStatusBar)];
+    return self.privateStatusBarView;
+}
+
+- (UIView *)privateStatusBarView {
+    if (!_privateStatusBarView) {
+        _privateStatusBarView = [[UIView alloc] initWithFrame:self.statusBarViewAnimationFrame1];
+        if (self.snapshotWindow) {
+            [_privateStatusBarView addSubview:CRStatusBarSnapShotView(self.displayUnderStatusBar)];
+        }
+        _privateStatusBarView.clipsToBounds = YES;
     }
-    statusBarView.clipsToBounds = YES;
-    return statusBarView;
+    return _privateStatusBarView;
 }
 
 - (CGRect)statusBarViewAnimationFrame1 {

--- a/CRToast/CRToastManager.m
+++ b/CRToast/CRToastManager.m
@@ -308,7 +308,7 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
     
     notification.state = CRToastStateEntering;
     
-    [self showNotification:notification notificationView:notificationView statusBarView:statusBarView inwardAnimationBlock:inwardAnimationsBlock inwardCompletionAnimationBlock:inwardAnimationsCompletionBlock];
+    [self showNotification:notification inwardAnimationBlock:inwardAnimationsBlock inwardCompletionAnimationBlock:inwardAnimationsCompletionBlock];
     
     if (notification.text.length > 0 || notification.subtitleText.length > 0) {
         // Synchronous notifications (say, tapping a button that presents a toast) cause VoiceOver to read the button immediately, which interupts the toast. A short delay (not the best solution :/) allows the toast to interupt the button.
@@ -319,8 +319,6 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
 }
 
 - (void)showNotification:(CRToast *)notification
-        notificationView:(UIView *)notificationView
-            statusBarView:(UIView *)statusBarView
      inwardAnimationBlock:(CRToastAnimationStepBlock)inwardAnimationsBlock
 inwardCompletionAnimationBlock:(CRToastAnimationCompletionBlock)inwardAnimationsCompletionBlock {
     
@@ -340,6 +338,9 @@ inwardCompletionAnimationBlock:(CRToastAnimationCompletionBlock)inwardAnimations
                              completion:inwardAnimationsCompletionBlock];
         } break;
         case CRToastAnimationTypeGravity: {
+            UIView *notificationView = notification.notificationView;
+            UIView *statusBarView = notification.statusBarView;
+            
             [notification initiateAnimator:_notificationWindow.rootViewController.view];
             [notification.animator removeAllBehaviors];
             UIGravityBehavior *gravity = [[UIGravityBehavior alloc] initWithItems:@[notificationView, statusBarView]];


### PR DESCRIPTION
Since toast.notificationView was generating new view every time, accessing it was returning a new
CRToastView every time its accessed. This removes that allowing for multiple, subsequent accesses
to a toast's notificationView if needed for whatever reason

This reverts recent changes made to fix the crash in regards the gravity in animation.

Each toast now generates one notificationView and one statusBarView and returns the generated one instead of generating a new one on every access.
I'm currently not aware of any other consequences in regards to these changes as everything still sees to be working fine